### PR TITLE
Update hello-feature-remote-desktop.md

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-feature-remote-desktop.md
+++ b/windows/security/identity-protection/hello-for-business/hello-feature-remote-desktop.md
@@ -23,10 +23,10 @@ ms.reviewer:
 
 - Windows 10
 - Windows 11
-- Cloud only, Hybrid, and On-premises only  Windows Hello for Business deployments
+- Hybrid and On-premises Windows Hello for Business deployments
 - Azure AD joined, Hybrid Azure AD joined, and Enterprise joined devices
 
-Windows Hello for Business supports using a certificate deployed to a Windows Hello for Business container as a supplied credential to establish a remote desktop connection to a server or another device. This functionality is not supported for key trust deployments. This feature takes advantage of the redirected smart card capabilities of the remote desktop protocol. Windows Hello for Business key trust can be used with [Windows Defender Remote Credential Guard](../remote-credential-guard.md) to establish a remote desktop protocol connection.
+Windows Hello for Business supports using a certificate deployed to a Windows Hello for Business container as a supplied credential to establish a remote desktop connection to a server or another device. This feature takes advantage of the redirected smart card capabilities of the remote desktop protocol. Windows Hello for Business key trust can be used with [Windows Defender Remote Credential Guard](../remote-credential-guard.md) to establish a remote desktop protocol connection.
 
 Microsoft continues to investigate supporting using keys trust for supplied credentials in a future release.
 
@@ -34,7 +34,7 @@ Microsoft continues to investigate supporting using keys trust for supplied cred
 
 **Requirements**
 
-- Cloud only, Hybrid, and On-premises only Windows Hello for Business deployments
+- Hybrid and On-premises Windows Hello for Business deployments
 - Azure AD joined, Hybrid Azure AD joined, and Enterprise joined devices
 - Biometric enrollments
 - Windows 10, version 1809 or later


### PR DESCRIPTION
Following two updates suggested - 

(I). Suggest updating the following statement: 
From : "- Cloud only, Hybrid, and On-premises only Windows Hello for Business deployments" 
To: " Hybrid and On-premises Windows Hello for Business deployments"
due to the following two reasons - 
(i). customer was confused that that RDP to Azure AD Joined device using WHfB was possible with "cloud only" environment (without any only-premises infrastructure). At this time, in order to RDP to Azure AD Joined device using WHfB, a certificate needs to be installed on the devices, which in turn requires on-premises infrastructure (Certificate Authority server and AD DS). 

(ii) This seems to contradict with other documents detailing the procedures where it this is stated in the context of "Hybrid deployment." Other documents URL copied below - 
https://docs.microsoft.com/en-us/windows/security/identity-protection/hello-for-business/hello-hybrid-aadj-sso-base
https://docs.microsoft.com/en-us/windows/security/identity-protection/hello-for-business/hello-hybrid-aadj-sso-cert
https://docs.microsoft.com/en-us/windows/security/identity-protection/hello-for-business/hello-deployment-rdp-certs

(II) Suggest removing the following phrase
"This functionality is not supported for key trust deployments."
 because "deploying WHfB for RDP" is possible with "key trust" per following documents - 
https://docs.microsoft.com/en-us/windows/security/identity-protection/hello-for-business/hello-hybrid-aadj-sso-base
https://docs.microsoft.com/en-us/windows/security/identity-protection/hello-for-business/hello-deployment-rdp-certs